### PR TITLE
feat: chaos engine UI, static pages, deployment configs, and README

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn api.main:app --host 0.0.0.0 --port $PORT

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ uv run python -m ingest.run_pipeline validate --season 2024 --round 21
 | **Data Sources** | Jolpica API, OpenF1 API, FastF1 |
 | **Database** | DuckDB (file-based, 17 tables) |
 | **Backend** | FastAPI + Pydantic + uvicorn |
-| **Frontend** | React 18 + TypeScript + Vite |
+| **Frontend** | React 19 + TypeScript + Vite |
 | **Styling** | Tailwind CSS + shadcn/ui |
 | **ML** | Rule-based baselines (scikit-learn in v2) |
 | **Testing** | pytest (85 tests) |

--- a/README.md
+++ b/README.md
@@ -2,53 +2,234 @@
 
 > "Think you can out-strategize the pit wall?"
 
-Undercut is an unofficial Formula 1 strategy simulation where users can repl historical race scenarios, make pit-wall decisions, and compare their choices against real outcomes, ML recommendations, and simulation-based alternatives.
+Undercut is an **unofficial Formula 1 strategy simulation** where users replay historical race scenarios, make pit-wall decisions, and compare their choices against:
+- **Historical outcomes** — what the real team did
+- **ML recommendations** — rule-based baseline models with explainable reasoning
+- **Simulation projections** — tire degradation, pit loss, and position impact models
 
-## Status
+## Try It Out
 
-This project is in active development. See the [project board](https://github.com/users/Taleef7/projects/5) for progress.
+- **Live Demo**: [https://undercut.vercel.app](https://undercut.vercel.app) *(update after deploy)*
+- **API Docs**: [https://undercut-api.railway.app/docs](https://undercut-api.railway.app/docs) *(update after deploy)*
+
+## Features
+
+- **3 Curated Scenarios** — Brazil 2024 (VER lap 32, NOR lap 40, VER lap 68)
+- **Real Race Data** — 1,137 laps, 54 stints, 35 pit stops from actual telemetry
+- **Rule-Based ML** — 5 pit-decision rules + 3 finish-position rules with confidence scores
+- **Chaos Engine** — "What if...?" modifiers: Safety Car, rain, tire cliff, slow stops, rival pits
+- **Simulation Engine** — Tire degradation curves, pit loss by circuit, scoring rubric
+- **Full Data Pipeline** — Jolpica + OpenF1 + FastF1 → DuckDB with 17 tables
+
+## Architecture
+
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│   Jolpica   │     │   OpenF1    │     │   FastF1    │
+│  (metadata) │     │ (telemetry) │     │  (legacy)   │
+└──────┬──────┘     └──────┬──────┘     └──────┬──────┘
+       │                   │                   │
+       └─────────┬─────────┴─────────┬─────────┘
+                 │                   │
+           ┌─────▼─────┐       ┌─────▼─────┐
+           │   Raw     │       │   Raw     │
+           │  (JSON)   │       │  (JSON)   │
+           └─────┬─────┘       └─────┬─────┘
+                 │                   │
+                 └─────────┬─────────┘
+                           │
+                    ┌──────▼──────┐
+                    │  Normalize  │
+                    │  (DuckDB)   │
+                    │  17 tables  │
+                    └──────┬──────┘
+                           │
+              ┌────────────┼────────────┐
+              │            │            │
+         ┌────▼────┐  ┌────▼────┐  ┌────▼────┐
+         │  Race   │  │ Feature │  │   API   │
+         │  State  │  │  Store  │  │ FastAPI │
+         └────┬────┘  └────┬────┘  └────┬────┘
+              │            │            │
+              └────────────┼────────────┘
+                           │
+                    ┌──────▼──────┐
+                    │   React     │
+                    │  Frontend   │
+                    └─────────────┘
+```
+
+### Data Pipeline (Sprint C)
+
+```bash
+# Seed reference data
+uv run python -m ingest.run_pipeline bootstrap --source jolpica --seasons 2024
+
+# Fetch a race weekend
+uv run python -m ingest.run_pipeline fetch-weekend --season 2024 --round 21
+
+# Normalize to canonical schema
+uv run python -m ingest.run_pipeline normalize --season 2024 --round 21
+
+# Build race state tables
+uv run python -m ingest.run_pipeline build-race-state --season 2024 --round 21
+
+# Build feature store
+uv run python -m ingest.run_pipeline build-features --season 2024 --round 21
+
+# Validate
+uv run python -m ingest.run_pipeline validate --season 2024 --round 21
+```
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| **Data Sources** | Jolpica API, OpenF1 API, FastF1 |
+| **Database** | DuckDB (file-based, 17 tables) |
+| **Backend** | FastAPI + Pydantic + uvicorn |
+| **Frontend** | React 18 + TypeScript + Vite |
+| **Styling** | Tailwind CSS + shadcn/ui |
+| **ML** | Rule-based baselines (scikit-learn in v2) |
+| **Testing** | pytest (85 tests) |
+| **Deploy** | Railway (backend), Vercel (frontend) |
 
 ## Project Structure
 
 ```
 undercut/
-├── data/               # Data files (raw, cached, processed)
-│   ├── cache/         # FastF1 cache
-│   └── decision_points/  # Curated scenarios
-├── docs/              # Documentation
-├── ingest/            # Data ingestion scripts
-├── sim/               # Simulation engine
-├── api/               # FastAPI backend
-└── web/               # React frontend
+├── api/                    # FastAPI backend
+│   ├── main.py            # API routes + CORS
+│   ├── models.py          # Pydantic schemas
+│   └── routers/           # (reserved for future)
+├── db/
+│   ├── migrations/        # 7 SQL schema files
+│   ├── seeds/             # Compounds + circuits
+│   └── apply_migrations.py
+├── data/
+│   ├── raw/               # Immutable API responses
+│   ├── decision_points/   # Curated YAML scenarios
+│   └── undercut.db        # DuckDB database
+├── ingest/
+│   ├── base_client.py     # Cache-first HTTP client
+│   ├── jolpica_client.py  # Jolpica API wrapper
+│   ├── openf1_client.py   # OpenF1 API wrapper
+│   ├── normalize/         # 10 normalizers
+│   ├── validate/          # Data quality checks
+│   ├── build/             # Race state + feature builders
+│   └── run_pipeline.py    # CLI orchestrator
+├── ml/
+│   └── baselines.py       # Rule-based ML models
+├── sim/
+│   ├── engine.py          # UndercutEngine
+│   ├── chaos.py           # ChaosEngine modifiers
+│   ├── scoring.py         # Decision scoring rubric
+│   ├── tire_model.py      # Degradation curves
+│   ├── pit_model.py       # Pit loss heuristics
+│   └── circuit_config.py  # Per-circuit constants
+├── web/                   # React frontend
+│   ├── src/
+│   │   ├── api/client.ts  # Typed fetch wrappers
+│   │   ├── components/    # Reusable UI
+│   │   └── pages/         # Game screens
+│   ├── package.json
+│   └── vercel.json
+└── tests/                 # 85 pytest tests
 ```
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/` | Health check |
+| `GET` | `/scenarios` | List all scenarios |
+| `GET` | `/scenarios/{id}` | Get scenario detail |
+| `POST` | `/scenarios/{id}/decision` | Submit decision, get score |
+| `POST` | `/scenarios/{id}/chaos` | Submit with chaos modifiers |
 
 ## Getting Started
 
+### Prerequisites
+
+- Python 3.11+
+- Node.js 18+
+- `uv` (Python package manager)
+
+### Backend
+
 ```bash
-# Install dependencies
+# Install Python dependencies
 uv sync
 
-# Set up environment
-cp .env.example .env
-# Edit .env with your settings
+# Set up database
+uv run python db/apply_migrations.py
+uv run python -c "import duckdb; conn = duckdb.connect('data/undercut.db'); conn.execute(open('db/seeds/seed_compounds.sql').read()); conn.execute(open('db/seeds/seed_circuits.sql').read()); conn.close()"
 
-# Run locally
-uv run python -m api.main
+# Load decision points
+uv run python -m ingest.load_decision_points data/decision_points/brazil_2024.yaml
+
+# Run API server
+uv run uvicorn api.main:app --reload --host 127.0.0.1 --port 8000
 ```
 
-## Tech Stack
+### Frontend
 
-- **Ingestion**: FastF1, DuckDB
-- **Backend**: FastAPI, Python 3.11
-- **Frontend**: React + TypeScript + Tailwind + shadcn/ui
-- **ML**: scikit-learn, XGBoost
-- **Deploy**: Vercel (frontend), Railway (backend)
+```bash
+cd web
+npm install
+npm run dev
+```
+
+The frontend will be available at `http://localhost:5173` and expects the API at `http://localhost:8000`.
+
+### Running Tests
+
+```bash
+# Backend tests
+uv run pytest tests/ -v
+
+# Frontend build check
+cd web && npm run build
+```
+
+## Decision Scoring Rubric
+
+| Condition | Score | Grade |
+|-----------|-------|-------|
+| Matches historical AND simulation confirms optimal | 90-100 | Masterful |
+| Matches historical (simulation neutral/confirming) | 75-89 | Strong |
+| Different from historical but simulation shows gain | 80-95 | Inspired call |
+| Different, simulation shows similar outcome | 55-70 | Risky |
+| Different, simulation shows position loss | 30-54 | Poor call |
+| Extreme misread of conditions | 0-29 | Off the wall |
+
+## Chaos Modifiers
+
+| Modifier | Effect |
+|----------|--------|
+| Safety Car | Reduces pit loss by ~18s |
+| Virtual Safety Car | Reduces pit loss by ~14s |
+| Rain Starts | Forces intermediate tires |
+| Tire Cliff Now | +8 laps of tire age |
+| Slow Pit Stop | +N seconds to pit loss |
+| Rival Pits This Lap | Compresses gap behind |
+| Red Flag | Free pit opportunity |
+
+## Data Sources
+
+| Source | Coverage | Use Case |
+|--------|----------|----------|
+| **Jolpica** | 1950-present | Circuits, drivers, constructors, results |
+| **OpenF1** | 2023-present | Laps, stints, pit stops, weather, positions |
+| **FastF1** | 2018-present | Gap filling, cross-validation |
+
+## Contributing
+
+This is a personal portfolio project. Issues and PRs are welcome but may be handled on a best-effort basis.
 
 ## Disclaimer
 
-This is an unofficial fan project created for educational and portfolio purposes. It is not affiliated with, endorsed by, or in any way officially connected with Formula 1, the FIA, any F1 team, driver, or data provider.
-
-All trademarks belong to their respective owners.
+This is an unofficial fan project created for educational and portfolio purposes. It is not affiliated with Formula 1, the FIA, any F1 team, driver, or data provider. All trademarks belong to their respective owners. Data is used under the terms of the respective source licenses and is intended for non-commercial personal use only.
 
 ## License
 

--- a/api/main.py
+++ b/api/main.py
@@ -12,7 +12,9 @@ from api.models import (
     DecisionResponse,
     DecisionRequest,
     SimulationSummary,
+    ChaosModifierRequest,
 )
+from sim.chaos import ChaosEngine, ChaosModifier
 
 app = FastAPI(title="Undercut API")
 
@@ -155,10 +157,91 @@ def submit_decision(decision_id: str, request: DecisionRequest):
         grade=score_data["grade"],
         historical_decision=row["actual_decision"],
         model_recommendation=score_data["model_recommendation"],
-        model_confidence=None,
-        model_top_features=[],
+        model_confidence=score_data.get("model_confidence"),
+        model_top_features=score_data.get("model_top_features", []),
         simulation_summary=SimulationSummary(
             expected_position=sim_result.expected_position,
+            expected_finish_position_band=score_data.get("expected_finish_position_band"),
+            risk_score=sim_result.risk_score,
+        ),
+        explanation=score_data["explanation"],
+        tradeoffs=[],
+    )
+
+
+@app.post("/scenarios/{decision_id}/chaos", response_model=DecisionResponse)
+def submit_chaos_decision(decision_id: str, request: ChaosModifierRequest):
+    conn = duckdb.connect(str(DB_PATH))
+    df = conn.execute(
+        "SELECT * FROM race_state_decision_point WHERE decision_point_id = ?",
+        (decision_id,),
+    ).fetchdf()
+    conn.close()
+
+    if df.empty:
+        raise HTTPException(status_code=404, detail="Scenario not found")
+
+    row = df.to_dict(orient="records")[0]
+
+    available_actions = json.loads(row["available_actions_json"])
+    if request.action not in available_actions:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid action '{request.action}'. Available: {available_actions}",
+        )
+
+    gap_ahead = row["gap_ahead_seconds"]
+    gap_behind = row["gap_behind_seconds"]
+    if gap_ahead is None:
+        gap_ahead = 0.0
+    if gap_behind is None:
+        gap_behind = 0.0
+
+    context = ScenarioContext(
+        driver=row["driver_id"],
+        lap=int(row["lap_number"] or 0),
+        position=int(row.get("current_position") or 1),
+        compound=row["compound"],
+        stint_age=int(row.get("stint_age_laps") or 0),
+        gap_ahead=float(gap_ahead),
+        gap_behind=float(gap_behind),
+        laps_remaining=int(row.get("laps_remaining") or 0),
+        safety_car_active=row.get("safety_car_active") or False,
+        virtual_safety_car_active=row.get("virtual_safety_car_active") or False,
+        rainfall=row.get("rainfall") or False,
+        track_status=row.get("track_status") or "green",
+        circuit="interlagos",
+    )
+
+    chaos_engine = ChaosEngine()
+    modifiers = [ChaosModifier(**m) for m in request.modifiers]
+    context = chaos_engine.apply_modifiers(context, modifiers)
+
+    engine = UndercutEngine(circuit="interlagos")
+    sim_result = engine.simulate_decision(
+        StrategyDecision(action=request.action, compound=None),
+        context,
+        row["actual_decision"],
+    )
+
+    score_data = engine.evaluate_strategy(
+        StrategyDecision(action=request.action, compound=None),
+        context,
+        row["actual_decision"],
+    )
+
+    return DecisionResponse(
+        scenario_id=row["decision_point_id"],
+        user_action=request.action,
+        score=score_data["score"],
+        grade=score_data["grade"],
+        historical_decision=row["actual_decision"],
+        model_recommendation=score_data["model_recommendation"],
+        model_confidence=score_data.get("model_confidence"),
+        model_top_features=score_data.get("model_top_features", []),
+        simulation_summary=SimulationSummary(
+            expected_position=sim_result.expected_position,
+            expected_finish_position_band=score_data.get("expected_finish_position_band"),
             risk_score=sim_result.risk_score,
         ),
         explanation=score_data["explanation"],

--- a/api/main.py
+++ b/api/main.py
@@ -15,13 +15,15 @@ from api.models import (
     SimulationSummary,
     ChaosModifierRequest,
 )
-from sim.chaos import ChaosEngine, ChaosModifier
-
 app = FastAPI(title="Undercut API")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=[
+        "http://localhost:5173",
+        "https://undercut.vercel.app",
+        "https://*.vercel.app",
+    ],
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -155,6 +157,9 @@ def submit_decision(decision_id: str, request: DecisionRequest):
         row["actual_decision"],
     )
 
+    tire_risk = "high" if context.stint_age > 25 else "medium" if context.stint_age > 18 else "low"
+    track_position_risk = "high" if sim_result.risk_score > 0.7 else "medium" if sim_result.risk_score > 0.4 else "low"
+
     return DecisionResponse(
         scenario_id=row["decision_point_id"],
         user_action=request.action,
@@ -168,6 +173,8 @@ def submit_decision(decision_id: str, request: DecisionRequest):
             expected_position=sim_result.expected_position,
             expected_finish_position_band=score_data.get("expected_finish_position_band"),
             risk_score=sim_result.risk_score,
+            tire_risk=tire_risk,
+            track_position_risk=track_position_risk,
         ),
         explanation=score_data["explanation"],
         tradeoffs=[],
@@ -219,7 +226,7 @@ def submit_chaos_decision(decision_id: str, request: ChaosModifierRequest):
     )
 
     chaos_engine = ChaosEngine()
-    modifiers = [ChaosModifier(**m) for m in request.modifiers]
+    modifiers = [ChaosModifier(**m.model_dump()) for m in request.modifiers]
     context = chaos_engine.apply_modifiers(context, modifiers)
 
     engine = UndercutEngine(circuit="interlagos")
@@ -235,6 +242,9 @@ def submit_chaos_decision(decision_id: str, request: ChaosModifierRequest):
         row["actual_decision"],
     )
 
+    tire_risk = "high" if context.stint_age > 25 else "medium" if context.stint_age > 18 else "low"
+    track_position_risk = "high" if sim_result.risk_score > 0.7 else "medium" if sim_result.risk_score > 0.4 else "low"
+
     return DecisionResponse(
         scenario_id=row["decision_point_id"],
         user_action=request.action,
@@ -248,6 +258,8 @@ def submit_chaos_decision(decision_id: str, request: ChaosModifierRequest):
             expected_position=sim_result.expected_position,
             expected_finish_position_band=score_data.get("expected_finish_position_band"),
             risk_score=sim_result.risk_score,
+            tire_risk=tire_risk,
+            track_position_risk=track_position_risk,
         ),
         explanation=score_data["explanation"],
         tradeoffs=[],

--- a/api/models.py
+++ b/api/models.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Dict, Any
 from pydantic import BaseModel
 
 
@@ -57,3 +57,8 @@ class DecisionResponse(BaseModel):
 class DecisionRequest(BaseModel):
     action: str
     compound: Optional[str] = None
+
+
+class ChaosModifierRequest(BaseModel):
+    action: str
+    modifiers: List[Dict[str, Any]] = []

--- a/api/models.py
+++ b/api/models.py
@@ -1,4 +1,5 @@
-from typing import List, Optional, Dict, Any
+from enum import Enum
+from typing import List, Optional
 from pydantic import BaseModel
 
 
@@ -59,6 +60,21 @@ class DecisionRequest(BaseModel):
     compound: Optional[str] = None
 
 
+class ModifierType(str, Enum):
+    safety_car = "safety_car"
+    vsc = "vsc"
+    rain_starts = "rain_starts"
+    tire_cliff_now = "tire_cliff_now"
+    slow_pit_stop = "slow_pit_stop"
+    rival_pits_this_lap = "rival_pits_this_lap"
+    red_flag = "red_flag"
+
+
+class ChaosModifierItem(BaseModel):
+    modifier_type: ModifierType
+    modifier_value: float = 0.0
+
+
 class ChaosModifierRequest(BaseModel):
     action: str
-    modifiers: List[Dict[str, Any]] = []
+    modifiers: List[ChaosModifierItem] = []

--- a/journal.md
+++ b/journal.md
@@ -210,7 +210,7 @@ Migration `005_corrections.sql`:
 - PR #87 created and merged (frontend bootstrap + core pages + Codex review fixes)
 
 ### Test Count
-- **101 tests passing** (68 + 13 baselines + 15 chaos + 5 existing)
+- **85 tests passing**
 
 ---
 
@@ -222,7 +222,7 @@ Migration `005_corrections.sql`:
 - ✅ ML: rule-based baselines with explainable recommendations
 - ✅ Simulation: circuit-aware lap times, tire degradation, pit loss, position impact
 - ✅ Frontend: 3 core pages with dark theme, responsive layout, typed API client
-- ✅ Tests: 101 passing
+- ✅ Tests: 85 passing
 
 ### What's Next (Week 4 — Chaos + Deploy + Polish)
 Per GitHub issues #69-#84 and PROJECT_PLAN Week 4:
@@ -251,9 +251,7 @@ Per GitHub issues #69-#84 and PROJECT_PLAN Week 4:
    - README screenshots
 
 ### Known Issues
-- Frontend needs chaos UI integration
-- No deployment config yet
 - No real production database (still DuckDB)
 - Only 3 curated scenarios
 - No real ML model (rule-based only)
-- Methodology page not built
+- Frontend PR review #88 identified API client error handling and methodology accuracy gaps (fixed in this update)

--- a/journal.md
+++ b/journal.md
@@ -143,10 +143,117 @@ Migration `005_corrections.sql`:
 
 ---
 
-## Next Sprint: C — Data Ingestion Expansion
-- C1: Jolpica REST client (`ingest/jolpica_client.py`)
-- C2: OpenF1 REST client (`ingest/openf1_client.py`)
-- C3: Normalization modules (10 files in `ingest/normalize/`)
-- C4: Race state builder (`ingest/build/build_race_state.py`)
-- C5: Feature store builder (`ingest/build/build_features.py`)
-- C6: CLI orchestration (`ingest/run_pipeline.py`)
+---
+
+## 2026-05-03 — Sprint C Completed: Full Data Pipeline
+
+### C1-C4: REST Clients + Normalization
+- `ingest/base_client.py`: ABC with cache-first `_get()`, exponential backoff with jitter (3 retries)
+- `ingest/jolpica_client.py`: 7 endpoints (circuits, drivers, constructors, results, qualifying, laps, pit stops), paginated lap fetching
+- `ingest/openf1_client.py`: 9 endpoints (meetings, sessions, laps, stints, pit, intervals, positions, weather, race control), dynamic key resolution
+- 4 dimension normalizers (circuits, drivers, constructors, sessions) + 6 fact normalizers (results, laps, stints, pit stops, weather, race control)
+- Source priority config for query-time deduplication (openf1=1, fastf1=2, jolpica=3)
+- All normalizers produce `record_hash` for idempotent upserts
+
+### C5-C6: Builders + CLI
+- `ingest/build/build_race_state.py`: `race_state_driver_lap_fact` (33 cols) + `race_state_field_lap` (18 cols), hard/soft prereq checks
+- `ingest/build/build_features.py`: `feature_pit_decision` + `feature_undercut_opportunity`
+- `ingest/run_pipeline.py`: 6 CLI commands (bootstrap, fetch-weekend, normalize, build-race-state, build-features, validate), `--force`, `--session R|Q`
+- `ingest/validate/`: 6 checks (null, unique, FK, lap range, record hash, row validation) + per-weekend report naming
+
+### Pipeline Validation (Brazil 2024 Round 21)
+- Bootstrap: 78 circuits, 25 drivers, 10 constructors
+- Fetch: Jolpica + OpenF1 (Race + Qualifying sessions)
+- Normalize: 1137 laps, 54 stints, 35 pit stops, 201 weather samples, 111 race control events
+- Build: 1137 driver_lap rows, 69 field_lap rows, 1137 pit_decision rows, 1137 undercut rows
+- Validate: 40 warnings (soft checks), 0 errors
+
+### Test Count
+- **68 tests passing** (up from 5)
+
+### PR
+- PR #86 created and merged
+
+---
+
+## 2026-05-03 — Sprint D+E+G: ML Baselines + Frontend + Chaos
+
+### D: Rule-Based ML Baselines (`ml/baselines.py`)
+- `predict_pit_decision()`: 5 prioritized rules (SC, rain, tire cliff, undercut threat, too late) + default
+- `predict_finish_position_band()`: 3 rules (pace delta, SC compression, gap to leader) + default
+- Confidence formula: `0.5 + 0.45 * (rules_fired / total)` capped at 0.95
+- 13 tests
+
+### G: Chaos Engine (`sim/chaos.py`)
+- `ChaosEngine.apply_modifier()`: 7 modifier types (safety_car, vsc, rain_starts, tire_cliff_now, slow_pit_stop, rival_pits_this_lap, red_flag)
+- Returns new `ScenarioContext` (immutable)
+- `POST /scenarios/{id}/chaos` endpoint added to API
+- 15 tests
+
+### E: Frontend Bootstrap + Core Pages
+- Vite + React 18 + TypeScript scaffolded
+- Tailwind CSS with dark mode (`darkMode: 'class'`) + custom F1 theme colors
+- shadcn/ui initialized (Button, Card, Badge components)
+- Typed API client (`src/api/client.ts`) with all endpoint wrappers
+- **ScenarioSelect.tsx**: responsive card grid, circuit name parsing, decision type badges
+- **ScenarioPlay.tsx**: driver/position display, gap cards with arrows, tire compound + cliff warning, track status badge, weather conditions, radio quote, stint timeline, action buttons
+- **DecisionResult.tsx**: score display, grade coloring, historical comparison, model recommendation, risk gauge, tradeoffs list, explanation, replay CTAs
+- **StintTimeline.tsx**: SVG bar with compound colors, current lap marker
+- Build passes with zero TypeScript errors
+
+### Integration
+- Engine now calls ML baselines for `model_recommendation`, `model_confidence`, `model_top_features`
+- API returns real ML predictions instead of placeholders
+- `docs/api_contract.md` updated with `/chaos` endpoint
+
+### PR
+- PR #87 created and merged (frontend bootstrap + core pages + Codex review fixes)
+
+### Test Count
+- **101 tests passing** (68 + 13 baselines + 15 chaos + 5 existing)
+
+---
+
+## Current Status
+
+### What's Working
+- ✅ Full data pipeline: raw → canonical → race_state → feature_store
+- ✅ API: 4 endpoints (health, list scenarios, get scenario, submit decision, chaos decision)
+- ✅ ML: rule-based baselines with explainable recommendations
+- ✅ Simulation: circuit-aware lap times, tire degradation, pit loss, position impact
+- ✅ Frontend: 3 core pages with dark theme, responsive layout, typed API client
+- ✅ Tests: 101 passing
+
+### What's Next (Week 4 — Chaos + Deploy + Polish)
+Per GitHub issues #69-#84 and PROJECT_PLAN Week 4:
+
+1. **Frontend polish** (#69-#72, #75)
+   - Chaos modifier toggles in DecisionResult
+   - "What if...?" section with SC, rain, slow stop options
+   - Alternate outcome display
+   - Disclaimer footer
+   - Methodology page
+
+2. **Deployment** (#76-#81)
+   - Railway backend (Dockerfile, Procfile, env vars)
+   - Vercel frontend (vercel.json, build config)
+   - Health check endpoint verification
+
+3. **Documentation** (#73-#75, #82-#84)
+   - README polish with screenshots
+   - Methodology page content
+   - Legal disclaimer
+   - Loom walkthrough script
+
+4. **Portfolio polish**
+   - 90-second demo video
+   - Custom domain setup
+   - README screenshots
+
+### Known Issues
+- Frontend needs chaos UI integration
+- No deployment config yet
+- No real production database (still DuckDB)
+- Only 3 curated scenarios
+- No real ML model (rule-based only)
+- Methodology page not built

--- a/ml/baselines.py
+++ b/ml/baselines.py
@@ -1,0 +1,76 @@
+from typing import Tuple, List
+from sim.scoring import ScenarioContext
+
+TIRE_CLIFF_THRESHOLDS = {"soft": 18, "medium": 28, "hard": 38, "intermediate": 25, "wet": 30}
+
+
+def predict_pit_decision(context: ScenarioContext) -> Tuple[str, float, List[str]]:
+    """Rule-based pit decision baseline."""
+    reasons = []
+
+    # Rule 1: Safety car
+    if getattr(context, 'safety_car_active', False):
+        reasons.append("Safety car on track — pitting now loses track position")
+        return "stay_out", 0.9, reasons
+
+    # Rule 2: Rain
+    if getattr(context, 'rainfall', False) or getattr(context, 'track_status', '') in ('wet', 'rain_starts'):
+        reasons.append("Wet conditions — need intermediate tires")
+        return "pit_now", 0.85, reasons
+
+    # Rule 3: Tire cliff
+    threshold = TIRE_CLIFF_THRESHOLDS.get(context.compound.lower(), 30)
+    if context.stint_age > threshold:
+        reasons.append("Tires approaching cliff")
+        return "pit_now", 0.8, reasons
+
+    # Rule 4: Undercut threat
+    gap_behind = getattr(context, 'gap_behind', 999)
+    if 0 < gap_behind < 3.0 and getattr(context, 'opponent_fresher_tires', False):
+        reasons.append("Undercut threat from behind")
+        return "pit_now", 0.75, reasons
+
+    # Rule 5: Too late
+    if getattr(context, 'laps_remaining', 999) < 8:
+        reasons.append("Too few laps remaining to benefit from fresh tires")
+        return "stay_out", 0.9, reasons
+
+    # Default
+    reasons.append("No urgent signal to pit")
+    confidence = min(0.95, 0.5 + 0.45 * (len(reasons) / 5))
+    return "stay_out", confidence, reasons
+
+
+def predict_finish_position_band(context: ScenarioContext, sim_result) -> Tuple[str, float, List[str]]:
+    """Predict finish position band."""
+    reasons = []
+    position = getattr(context, 'position', 10)
+    gap_ahead = getattr(context, 'gap_ahead', 0)
+
+    # Rule 1: Pace delta
+    if position <= 3 and gap_ahead < 5:
+        band = "P1-P3"
+        reasons.append("Running in podium positions with small gap to leader")
+    elif position <= 6:
+        band = "P4-P6"
+        reasons.append("Running in midfield top positions")
+    elif position <= 10:
+        band = "P7-P10"
+        reasons.append("Running in lower midfield")
+    elif position <= 15:
+        band = "P11-P15"
+        reasons.append("Running in backmarker positions")
+    else:
+        band = "P16+"
+        reasons.append("Running at the back of the field")
+
+    # Rule 2: Safety car compression
+    if getattr(context, 'safety_car_active', False):
+        bands = ["P1-P3", "P4-P6", "P7-P10", "P11-P15", "P16+"]
+        idx = bands.index(band)
+        if idx > 0:
+            band = bands[idx - 1]
+            reasons.append("Safety car compresses the field — improves position band")
+
+    confidence = min(0.95, 0.5 + 0.1 * len(reasons))
+    return band, confidence, reasons

--- a/ml/baselines.py
+++ b/ml/baselines.py
@@ -10,8 +10,8 @@ def predict_pit_decision(context: ScenarioContext) -> Tuple[str, float, List[str
 
     # Rule 1: Safety car
     if getattr(context, 'safety_car_active', False):
-        reasons.append("Safety car on track — pitting now loses track position")
-        return "stay_out", 0.9, reasons
+        reasons.append("Safety car reduces pit loss — good time to pit")
+        return "pit_now", 0.85, reasons
 
     # Rule 2: Rain
     if getattr(context, 'rainfall', False) or getattr(context, 'track_status', '') in ('wet', 'rain_starts'):
@@ -44,7 +44,7 @@ def predict_pit_decision(context: ScenarioContext) -> Tuple[str, float, List[str
 def predict_finish_position_band(context: ScenarioContext, sim_result) -> Tuple[str, float, List[str]]:
     """Predict finish position band."""
     reasons = []
-    position = getattr(context, 'position', 10)
+    position = getattr(sim_result, 'expected_position', getattr(context, 'position', 10))
     gap_ahead = getattr(context, 'gap_ahead', 0)
 
     # Rule 1: Pace delta

--- a/sim/chaos.py
+++ b/sim/chaos.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass, replace
+from typing import Any
+from sim.scoring import ScenarioContext
+from sim.circuit_config import CIRCUIT_CONFIG
+
+
+@dataclass
+class ChaosModifier:
+    modifier_type: str
+    modifier_value: float = 0.0
+
+
+class ChaosEngine:
+    def apply_modifier(self, context: ScenarioContext, modifier: ChaosModifier) -> ScenarioContext:
+        kwargs = {}
+
+        if modifier.modifier_type == "safety_car":
+            kwargs['safety_car_active'] = True
+            kwargs['modifier_pit_loss_delta'] = getattr(context, 'modifier_pit_loss_delta', 0) - 18.0
+        elif modifier.modifier_type == "vsc":
+            kwargs['virtual_safety_car_active'] = True
+            kwargs['modifier_pit_loss_delta'] = getattr(context, 'modifier_pit_loss_delta', 0) - 14.0
+        elif modifier.modifier_type == "rain_starts":
+            kwargs['rainfall'] = True
+            kwargs['track_status'] = 'wet'
+        elif modifier.modifier_type == "tire_cliff_now":
+            kwargs['modifier_stint_age_delta'] = getattr(context, 'modifier_stint_age_delta', 0) + 8
+        elif modifier.modifier_type == "slow_pit_stop":
+            kwargs['modifier_pit_loss_delta'] = getattr(context, 'modifier_pit_loss_delta', 0) + modifier.modifier_value
+        elif modifier.modifier_type == "rival_pits_this_lap":
+            circuit_config = CIRCUIT_CONFIG.get(getattr(context, 'circuit', 'interlagos'), {})
+            pit_loss = circuit_config.get('pit_loss_seconds', 22.0)
+            kwargs['gap_behind'] = max(0, getattr(context, 'gap_behind', 0) - pit_loss)
+        elif modifier.modifier_type == "red_flag":
+            kwargs['track_status'] = 'red_flag'
+        else:
+            raise ValueError(f"Unknown modifier type: {modifier.modifier_type}")
+
+        return replace(context, **kwargs)
+
+    def apply_modifiers(self, context: ScenarioContext, modifiers: list[ChaosModifier]) -> ScenarioContext:
+        for modifier in modifiers:
+            context = self.apply_modifier(context, modifier)
+        return context

--- a/sim/engine.py
+++ b/sim/engine.py
@@ -1,13 +1,12 @@
 """
 Core Simulation Engine - Orchestrates pit, tire, and scoring models.
 """
-from typing import Dict, List, Any
+from typing import Dict, Any
 from dataclasses import dataclass
 from .circuit_config import CIRCUIT_CONFIG
 from .pit_model import get_pit_loss, estimate_pit_delta
-from .tire_model import TireState, estimate_lap_time, get_degradation_multiplier, is_in_tire_cliff_zone
+from .tire_model import TireState, estimate_lap_time, is_in_tire_cliff_zone
 from .scoring import score_decision, StrategyDecision, ScenarioContext
-from ml.baselines import predict_pit_decision, predict_finish_position_band
 
 @dataclass
 class SimResult:
@@ -40,7 +39,9 @@ class UndercutEngine:
             base_lap_time_ms = 90000
         else:
             base_lap_time_ms = circuit_config["base_lap_time_ms"]
-        tire_state = TireState(compound=context.compound, stint_age=context.stint_age)
+
+        effective_stint_age = context.stint_age + getattr(context, 'modifier_stint_age_delta', 0)
+        tire_state = TireState(compound=context.compound, stint_age=effective_stint_age)
         est_lap_time = estimate_lap_time(
             base_lap_time_ms=base_lap_time_ms,
             tire_state=tire_state
@@ -48,7 +49,13 @@ class UndercutEngine:
 
         # 2. Calculate position impact if pitting
         if decision.action.startswith("pit_"):
-            pit_loss = get_pit_loss(self.circuit)
+            pit_loss = get_pit_loss(self.circuit) + getattr(context, 'modifier_pit_loss_delta', 0.0)
+            # Safety car / VSC further reduces effective pit loss
+            if context.safety_car_active:
+                pit_loss = max(0.0, pit_loss - 18.0)
+            elif context.virtual_safety_car_active:
+                pit_loss = max(0.0, pit_loss - 14.0)
+
             pos_delta = estimate_pit_delta(
                 current_position=context.position,
                 gap_ahead=context.gap_ahead,
@@ -59,17 +66,20 @@ class UndercutEngine:
         else:
             # stay_out or extend_stint
             # Simplified: expect to keep position unless tires are in cliff
-            if is_in_tire_cliff_zone(context.compound, context.stint_age):
+            if is_in_tire_cliff_zone(context.compound, effective_stint_age):
                 expected_pos = context.position + 1
             else:
                 expected_pos = context.position
 
         # 3. Simple risk assessment
         risk_score = 0.5 # Neutral
-        if decision.action == "stay_out" and context.stint_age > 25:
+        if decision.action == "stay_out" and effective_stint_age > 25:
             risk_score = 0.8 # High risk of cliff
         elif decision.action.startswith("pit_") and context.gap_ahead < 5.0:
             risk_score = 0.7 # High risk of rejoining in traffic
+
+        if context.rainfall:
+            risk_score = min(risk_score + 0.1, 1.0)
 
         return SimResult(
             expected_position=expected_pos,

--- a/sim/engine.py
+++ b/sim/engine.py
@@ -103,12 +103,20 @@ class UndercutEngine:
             sim_outcomes
         )
 
+        from ml.baselines import predict_pit_decision, predict_finish_position_band
+
+        model_rec, model_conf, model_features = predict_pit_decision(context)
+        finish_band, finish_conf, finish_reasons = predict_finish_position_band(context, user_sim)
+
         return {
             "score": score_data["score"],
             "grade": score_data["grade"],
             "explanation": score_data["explanation"],
-            "model_recommendation": score_data["model_recommendation"],
+            "model_recommendation": model_rec,
+            "model_confidence": round(model_conf, 2),
+            "model_top_features": model_features[:3],
             "expected_position": user_sim.expected_position,
+            "expected_finish_position_band": finish_band,
             "risk_score": user_sim.risk_score,
             "estimated_lap_time": user_sim.estimated_lap_time,
         }

--- a/sim/scoring.py
+++ b/sim/scoring.py
@@ -91,12 +91,14 @@ def score_decision(
             grade = GRADE_POOR_CALL
             explanation = "Simulation suggests your choice would have cost positions"
     
+    effective_stint_age = context.stint_age + getattr(context, 'modifier_stint_age_delta', 0)
+
     # Bonus for reasonable decisions in gray areas
-    if user_action.startswith("pit_") and context.stint_age > 20:
+    if user_action.startswith("pit_") and effective_stint_age > 20:
         score = min(score + 10, 100)
         explanation += " Good timing on the pit stop!"
-    
-    if user_action == ACTION_STAY_OUT and context.stint_age < 10:
+
+    if user_action == ACTION_STAY_OUT and effective_stint_age < 10:
         score = max(score - 10, 0)
         explanation += " Tires still had life, pitting early was aggressive."
     

--- a/sim/scoring.py
+++ b/sim/scoring.py
@@ -34,6 +34,14 @@ class ScenarioContext:
     gap_ahead: float
     gap_behind: float
     laps_remaining: int
+    safety_car_active: bool = False
+    virtual_safety_car_active: bool = False
+    rainfall: bool = False
+    track_status: str = "green"
+    modifier_pit_loss_delta: float = 0.0
+    modifier_stint_age_delta: int = 0
+    opponent_fresher_tires: bool = False
+    circuit: str = "interlagos"
 
 
 def score_decision(

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -1,0 +1,90 @@
+import pytest
+from sim.scoring import ScenarioContext
+from ml.baselines import predict_pit_decision, predict_finish_position_band, TIRE_CLIFF_THRESHOLDS
+
+
+def test_predict_pit_safety_car_returns_stay_out():
+    context = ScenarioContext(
+        driver="VER", lap=32, position=2, compound="medium", stint_age=14,
+        gap_ahead=1.2, gap_behind=4.8, laps_remaining=39, safety_car_active=True,
+    )
+    action, conf, reasons = predict_pit_decision(context)
+    assert action == "stay_out"
+    assert conf == 0.9
+    assert any("Safety car" in r for r in reasons)
+
+
+def test_predict_pit_rain_returns_pit_now():
+    context = ScenarioContext(
+        driver="VER", lap=32, position=2, compound="medium", stint_age=14,
+        gap_ahead=1.2, gap_behind=4.8, laps_remaining=39, rainfall=True,
+    )
+    action, conf, reasons = predict_pit_decision(context)
+    assert action == "pit_now"
+    assert conf == 0.85
+    assert any("Wet" in r for r in reasons)
+
+
+def test_predict_pit_tire_cliff_returns_pit_now():
+    for compound, threshold in TIRE_CLIFF_THRESHOLDS.items():
+        context = ScenarioContext(
+            driver="VER", lap=32, position=2, compound=compound, stint_age=threshold + 1,
+            gap_ahead=1.2, gap_behind=4.8, laps_remaining=39,
+        )
+        action, conf, reasons = predict_pit_decision(context)
+        assert action == "pit_now", f"Failed for {compound}"
+        assert conf == 0.8
+        assert any("cliff" in r for r in reasons)
+
+
+def test_predict_pit_undercut_threat_returns_pit_now():
+    context = ScenarioContext(
+        driver="VER", lap=32, position=2, compound="medium", stint_age=14,
+        gap_ahead=1.2, gap_behind=2.5, laps_remaining=39, opponent_fresher_tires=True,
+    )
+    action, conf, reasons = predict_pit_decision(context)
+    assert action == "pit_now"
+    assert conf == 0.75
+    assert any("Undercut" in r for r in reasons)
+
+
+def test_predict_pit_too_late_returns_stay_out():
+    context = ScenarioContext(
+        driver="VER", lap=32, position=2, compound="medium", stint_age=14,
+        gap_ahead=1.2, gap_behind=4.8, laps_remaining=5,
+    )
+    action, conf, reasons = predict_pit_decision(context)
+    assert action == "stay_out"
+    assert conf == 0.9
+    assert any("few laps" in r for r in reasons)
+
+
+def test_predict_pit_default_returns_stay_out():
+    context = ScenarioContext(
+        driver="VER", lap=32, position=2, compound="medium", stint_age=10,
+        gap_ahead=1.2, gap_behind=4.8, laps_remaining=39,
+    )
+    action, conf, reasons = predict_pit_decision(context)
+    assert action == "stay_out"
+    assert conf > 0.5
+    assert any("No urgent" in r for r in reasons)
+
+
+def test_predict_finish_podium_band():
+    context = ScenarioContext(
+        driver="VER", lap=32, position=2, compound="medium", stint_age=14,
+        gap_ahead=1.2, gap_behind=4.8, laps_remaining=39,
+    )
+    band, conf, reasons = predict_finish_position_band(context, None)
+    assert band == "P1-P3"
+    assert any("podium" in r for r in reasons)
+
+
+def test_predict_finish_safety_car_improves_band():
+    context = ScenarioContext(
+        driver="VER", lap=32, position=8, compound="medium", stint_age=14,
+        gap_ahead=1.2, gap_behind=4.8, laps_remaining=39, safety_car_active=True,
+    )
+    band, conf, reasons = predict_finish_position_band(context, None)
+    assert band == "P4-P6"
+    assert any("Safety car" in r for r in reasons)

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -1,16 +1,15 @@
-import pytest
 from sim.scoring import ScenarioContext
 from ml.baselines import predict_pit_decision, predict_finish_position_band, TIRE_CLIFF_THRESHOLDS
 
 
-def test_predict_pit_safety_car_returns_stay_out():
+def test_predict_pit_safety_car_returns_pit_now():
     context = ScenarioContext(
         driver="VER", lap=32, position=2, compound="medium", stint_age=14,
         gap_ahead=1.2, gap_behind=4.8, laps_remaining=39, safety_car_active=True,
     )
     action, conf, reasons = predict_pit_decision(context)
-    assert action == "stay_out"
-    assert conf == 0.9
+    assert action == "pit_now"
+    assert conf == 0.85
     assert any("Safety car" in r for r in reasons)
 
 

--- a/tests/test_chaos.py
+++ b/tests/test_chaos.py
@@ -1,0 +1,109 @@
+import pytest
+from sim.scoring import ScenarioContext
+from sim.chaos import ChaosEngine, ChaosModifier
+
+
+def test_safety_car_modifier():
+    engine = ChaosEngine()
+    context = ScenarioContext(
+        driver="VER", lap=32, position=2, compound="medium", stint_age=14,
+        gap_ahead=1.2, gap_behind=4.8, laps_remaining=39,
+    )
+    mod = ChaosModifier(modifier_type="safety_car")
+    new_ctx = engine.apply_modifier(context, mod)
+    assert new_ctx.safety_car_active is True
+    assert new_ctx.modifier_pit_loss_delta == -18.0
+
+
+def test_vsc_modifier():
+    engine = ChaosEngine()
+    context = ScenarioContext(
+        driver="VER", lap=32, position=2, compound="medium", stint_age=14,
+        gap_ahead=1.2, gap_behind=4.8, laps_remaining=39,
+    )
+    mod = ChaosModifier(modifier_type="vsc")
+    new_ctx = engine.apply_modifier(context, mod)
+    assert new_ctx.virtual_safety_car_active is True
+    assert new_ctx.modifier_pit_loss_delta == -14.0
+
+
+def test_rain_starts_modifier():
+    engine = ChaosEngine()
+    context = ScenarioContext(
+        driver="VER", lap=32, position=2, compound="medium", stint_age=14,
+        gap_ahead=1.2, gap_behind=4.8, laps_remaining=39,
+    )
+    mod = ChaosModifier(modifier_type="rain_starts")
+    new_ctx = engine.apply_modifier(context, mod)
+    assert new_ctx.rainfall is True
+    assert new_ctx.track_status == "wet"
+
+
+def test_tire_cliff_now_modifier():
+    engine = ChaosEngine()
+    context = ScenarioContext(
+        driver="VER", lap=32, position=2, compound="medium", stint_age=14,
+        gap_ahead=1.2, gap_behind=4.8, laps_remaining=39,
+    )
+    mod = ChaosModifier(modifier_type="tire_cliff_now")
+    new_ctx = engine.apply_modifier(context, mod)
+    assert new_ctx.modifier_stint_age_delta == 8
+
+
+def test_slow_pit_stop_modifier():
+    engine = ChaosEngine()
+    context = ScenarioContext(
+        driver="VER", lap=32, position=2, compound="medium", stint_age=14,
+        gap_ahead=1.2, gap_behind=4.8, laps_remaining=39,
+    )
+    mod = ChaosModifier(modifier_type="slow_pit_stop", modifier_value=3.5)
+    new_ctx = engine.apply_modifier(context, mod)
+    assert new_ctx.modifier_pit_loss_delta == 3.5
+
+
+def test_rival_pits_this_lap_modifier():
+    engine = ChaosEngine()
+    context = ScenarioContext(
+        driver="VER", lap=32, position=2, compound="medium", stint_age=14,
+        gap_ahead=1.2, gap_behind=4.8, laps_remaining=39, circuit="interlagos",
+    )
+    mod = ChaosModifier(modifier_type="rival_pits_this_lap")
+    new_ctx = engine.apply_modifier(context, mod)
+    assert new_ctx.gap_behind == max(0, 4.8 - 22.0)
+
+
+def test_red_flag_modifier():
+    engine = ChaosEngine()
+    context = ScenarioContext(
+        driver="VER", lap=32, position=2, compound="medium", stint_age=14,
+        gap_ahead=1.2, gap_behind=4.8, laps_remaining=39,
+    )
+    mod = ChaosModifier(modifier_type="red_flag")
+    new_ctx = engine.apply_modifier(context, mod)
+    assert new_ctx.track_status == "red_flag"
+
+
+def test_unknown_modifier_raises_error():
+    engine = ChaosEngine()
+    context = ScenarioContext(
+        driver="VER", lap=32, position=2, compound="medium", stint_age=14,
+        gap_ahead=1.2, gap_behind=4.8, laps_remaining=39,
+    )
+    mod = ChaosModifier(modifier_type="alien_invasion")
+    with pytest.raises(ValueError, match="Unknown modifier type"):
+        engine.apply_modifier(context, mod)
+
+
+def test_apply_modifiers_chain():
+    engine = ChaosEngine()
+    context = ScenarioContext(
+        driver="VER", lap=32, position=2, compound="medium", stint_age=14,
+        gap_ahead=1.2, gap_behind=4.8, laps_remaining=39,
+    )
+    mods = [
+        ChaosModifier(modifier_type="safety_car"),
+        ChaosModifier(modifier_type="slow_pit_stop", modifier_value=2.0),
+    ]
+    new_ctx = engine.apply_modifiers(context, mods)
+    assert new_ctx.safety_car_active is True
+    assert new_ctx.modifier_pit_loss_delta == -16.0

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -81,6 +81,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -696,29 +697,6 @@
         "@noble/ciphers": "^1.0.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -1219,6 +1197,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2032,6 +2011,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2042,6 +2022,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2128,6 +2109,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -2371,6 +2353,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2623,6 +2606,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3425,6 +3409,7 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3681,6 +3666,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4265,6 +4251,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
       "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5689,6 +5676,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5864,6 +5852,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5873,6 +5862,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5892,6 +5882,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -6017,7 +6008,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -6770,6 +6762,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6948,6 +6941,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7262,6 +7256,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.2.tgz",
       "integrity": "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,16 +2,24 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import ScenarioSelect from './pages/ScenarioSelect';
 import ScenarioPlay from './pages/ScenarioPlay';
 import DecisionResult from './pages/DecisionResult';
+import Disclaimer from './pages/Disclaimer';
+import Methodology from './pages/Methodology';
+import Footer from './components/Footer';
 
 function App() {
   return (
     <BrowserRouter>
-      <div className="min-h-screen bg-background text-foreground">
-        <Routes>
-          <Route path="/" element={<ScenarioSelect />} />
-          <Route path="/scenario/:id" element={<ScenarioPlay />} />
-          <Route path="/result" element={<DecisionResult />} />
-        </Routes>
+      <div className="min-h-screen bg-background text-foreground flex flex-col">
+        <div className="flex-1">
+          <Routes>
+            <Route path="/" element={<ScenarioSelect />} />
+            <Route path="/scenario/:id" element={<ScenarioPlay />} />
+            <Route path="/result" element={<DecisionResult />} />
+            <Route path="/disclaimer" element={<Disclaimer />} />
+            <Route path="/methodology" element={<Methodology />} />
+          </Routes>
+        </div>
+        <Footer />
       </div>
     </BrowserRouter>
   );

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -64,6 +64,11 @@ export async function getScenario(id: string): Promise<ScenarioDetail> {
   return res.json();
 }
 
+export interface ChaosModifier {
+  modifier_type: string;
+  modifier_value?: number;
+}
+
 export async function submitDecision(id: string, action: string): Promise<DecisionResponse> {
   const res = await fetch(`${API_BASE}/scenarios/${id}/decision`, {
     method: "POST",
@@ -71,5 +76,19 @@ export async function submitDecision(id: string, action: string): Promise<Decisi
     body: JSON.stringify({ action }),
   });
   if (!res.ok) throw new Error(`Failed to submit decision: ${res.status}`);
+  return res.json();
+}
+
+export async function submitChaosDecision(
+  id: string,
+  action: string,
+  modifiers: ChaosModifier[]
+): Promise<DecisionResponse> {
+  const res = await fetch(`${API_BASE}/scenarios/${id}/chaos`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action, modifiers }),
+  });
+  if (!res.ok) throw new Error(`Failed to submit chaos decision: ${res.status}`);
   return res.json();
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -54,13 +54,19 @@ export interface DecisionResponse {
 
 export async function getScenarios(): Promise<ScenarioSummary[]> {
   const res = await fetch(`${API_BASE}/scenarios`);
-  if (!res.ok) throw new Error(`Failed to fetch scenarios: ${res.status}`);
+  if (!res.ok) {
+    const errBody = await res.json().catch(() => ({ detail: res.statusText }));
+    throw new Error(errBody.detail || `HTTP ${res.status}`);
+  }
   return res.json();
 }
 
 export async function getScenario(id: string): Promise<ScenarioDetail> {
   const res = await fetch(`${API_BASE}/scenarios/${id}`);
-  if (!res.ok) throw new Error(`Failed to fetch scenario: ${res.status}`);
+  if (!res.ok) {
+    const errBody = await res.json().catch(() => ({ detail: res.statusText }));
+    throw new Error(errBody.detail || `HTTP ${res.status}`);
+  }
   return res.json();
 }
 
@@ -75,7 +81,10 @@ export async function submitDecision(id: string, action: string): Promise<Decisi
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ action }),
   });
-  if (!res.ok) throw new Error(`Failed to submit decision: ${res.status}`);
+  if (!res.ok) {
+    const errBody = await res.json().catch(() => ({ detail: res.statusText }));
+    throw new Error(errBody.detail || `HTTP ${res.status}`);
+  }
   return res.json();
 }
 
@@ -89,6 +98,9 @@ export async function submitChaosDecision(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ action, modifiers }),
   });
-  if (!res.ok) throw new Error(`Failed to submit chaos decision: ${res.status}`);
+  if (!res.ok) {
+    const errBody = await res.json().catch(() => ({ detail: res.statusText }));
+    throw new Error(errBody.detail || `HTTP ${res.status}`);
+  }
   return res.json();
 }

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -1,0 +1,21 @@
+import { Link } from "react-router-dom";
+
+export default function Footer() {
+  return (
+    <footer className="border-t border-border bg-card py-4 px-6 mt-auto">
+      <div className="max-w-6xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-2 text-xs text-muted-foreground">
+        <div>
+          Undercut — F1 Strategy Simulator
+        </div>
+        <div className="flex items-center gap-4">
+          <Link to="/methodology" className="hover:text-foreground transition-colors">
+            Methodology
+          </Link>
+          <Link to="/disclaimer" className="hover:text-foreground transition-colors">
+            Disclaimer
+          </Link>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -1,0 +1,30 @@
+import * as SwitchPrimitive from "@base-ui/react/switch";
+import { cn } from "@/lib/utils";
+
+interface SwitchProps extends Omit<SwitchPrimitive.Switch.Root.Props, "ref"> {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+function Switch({ className, checked, onCheckedChange, ...props }: SwitchProps) {
+  return (
+    <SwitchPrimitive.Switch.Root
+      data-slot="switch"
+      checked={checked}
+      onCheckedChange={onCheckedChange}
+      className={cn(
+        "group/switch inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent bg-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[checked]:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Switch.Thumb
+        className={cn(
+          "pointer-events-none block size-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[checked]:translate-x-4 data-[unchecked]:translate-x-0"
+        )}
+      />
+    </SwitchPrimitive.Switch.Root>
+  );
+}
+
+export { Switch };

--- a/web/src/pages/DecisionResult.tsx
+++ b/web/src/pages/DecisionResult.tsx
@@ -1,8 +1,11 @@
+import { useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import type { ScenarioDetail, DecisionResponse } from "@/api/client";
-import { RotateCcw, ArrowRight } from "lucide-react";
+import { Switch } from "@/components/ui/switch";
+import type { ScenarioDetail, DecisionResponse, ChaosModifier } from "@/api/client";
+import { submitChaosDecision } from "@/api/client";
+import { RotateCcw, ArrowRight, Sparkles } from "lucide-react";
 
 const GRADE_COLORS: Record<string, string> = {
   Masterful: "text-gold",
@@ -26,6 +29,22 @@ function getRiskBarColor(score: number): string {
   return "bg-poor";
 }
 
+interface ModifierConfig {
+  key: string;
+  label: string;
+  defaultValue?: number;
+}
+
+const MODIFIERS: ModifierConfig[] = [
+  { key: "safety_car", label: "Safety Car" },
+  { key: "vsc", label: "Virtual Safety Car" },
+  { key: "rain_starts", label: "Rain Starts" },
+  { key: "tire_cliff_now", label: "Tire Cliff Now (+8 laps)" },
+  { key: "slow_pit_stop", label: "Slow Pit Stop (+3s)", defaultValue: 3 },
+  { key: "rival_pits_this_lap", label: "Rival Pits This Lap" },
+  { key: "red_flag", label: "Red Flag" },
+];
+
 export default function DecisionResult() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -33,6 +52,11 @@ export default function DecisionResult() {
     scenario?: ScenarioDetail;
     response?: DecisionResponse;
   } | null;
+
+  const [activeModifiers, setActiveModifiers] = useState<Record<string, boolean>>({});
+  const [chaosResult, setChaosResult] = useState<DecisionResponse | null>(null);
+  const [chaosLoading, setChaosLoading] = useState(false);
+  const [chaosError, setChaosError] = useState<string | null>(null);
 
   if (!state?.scenario || !state?.response) {
     return (
@@ -52,6 +76,35 @@ export default function DecisionResult() {
 
   const { scenario, response } = state;
   const sim = response.simulation_summary;
+
+  const toggleModifier = (key: string) => {
+    setActiveModifiers((prev) => ({ ...prev, [key]: !prev[key] }));
+    setChaosResult(null);
+    setChaosError(null);
+  };
+
+  const handleSimulateChaos = async () => {
+    const selected: ChaosModifier[] = MODIFIERS.filter((m) => activeModifiers[m.key]).map((m) => ({
+      modifier_type: m.key,
+      modifier_value: m.defaultValue,
+    }));
+
+    if (selected.length === 0) {
+      setChaosError("Select at least one modifier.");
+      return;
+    }
+
+    setChaosLoading(true);
+    setChaosError(null);
+    try {
+      const result = await submitChaosDecision(scenario.decision_point_id, response.user_action, selected);
+      setChaosResult(result);
+    } catch (err) {
+      setChaosError(err instanceof Error ? err.message : "Failed to simulate chaos scenario");
+    } finally {
+      setChaosLoading(false);
+    }
+  };
 
   return (
     <div className="min-h-screen bg-background text-foreground px-6 py-8">
@@ -164,7 +217,7 @@ export default function DecisionResult() {
         </div>
 
         {/* Actions */}
-        <div className="flex flex-col sm:flex-row gap-3">
+        <div className="flex flex-col sm:flex-row gap-3 mb-10">
           <Button
             variant="outline"
             className="flex-1"
@@ -184,6 +237,88 @@ export default function DecisionResult() {
             <ArrowRight size={16} className="mr-2" />
             Play Another
           </Button>
+        </div>
+
+        {/* Chaos Engine */}
+        <div className="border-t border-border pt-8">
+          <div className="flex items-center gap-2 mb-4">
+            <Sparkles size={18} className="text-primary" />
+            <h2 className="text-lg font-semibold text-foreground">What if...?</h2>
+          </div>
+          <p className="text-sm text-muted-foreground mb-4">
+            Toggle chaos modifiers to see how unexpected events would have changed the outcome of your decision.
+          </p>
+
+          <div className="bg-card border border-border rounded-xl p-4 mb-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {MODIFIERS.map((m) => (
+                <div key={m.key} className="flex items-center justify-between gap-3">
+                  <span className="text-sm text-foreground">{m.label}</span>
+                  <Switch
+                    checked={!!activeModifiers[m.key]}
+                    onCheckedChange={() => toggleModifier(m.key)}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {chaosError && (
+            <div className="text-destructive bg-destructive/10 border border-destructive/20 rounded-lg px-4 py-3 text-sm mb-4">
+              {chaosError}
+            </div>
+          )}
+
+          <Button
+            onClick={handleSimulateChaos}
+            disabled={chaosLoading}
+            className="mb-6"
+          >
+            <Sparkles size={16} className="mr-2" />
+            {chaosLoading ? "Simulating..." : "Simulate Chaos"}
+          </Button>
+
+          {chaosResult && (
+            <div className="bg-card border border-border rounded-xl p-4">
+              <div className="text-sm font-medium text-foreground mb-3">
+                Modified Result
+              </div>
+              <div className="grid grid-cols-2 gap-4 mb-3">
+                <div>
+                  <div className="text-xs text-muted-foreground">Score</div>
+                  <div className="text-lg font-semibold text-foreground">
+                    {chaosResult.score}
+                  </div>
+                  <div className={`text-xs font-medium ${getGradeColor(chaosResult.grade)}`}>
+                    {chaosResult.grade}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-xs text-muted-foreground">Expected Position</div>
+                  <div className="text-lg font-semibold text-foreground">
+                    P{chaosResult.simulation_summary.expected_position}
+                  </div>
+                </div>
+              </div>
+              <div className="mb-3">
+                <div className="flex items-center justify-between text-xs text-muted-foreground mb-1">
+                  <span>Risk Score</span>
+                  <span>{(chaosResult.simulation_summary.risk_score * 100).toFixed(0)}%</span>
+                </div>
+                <div className="w-full h-2 bg-secondary rounded-full overflow-hidden">
+                  <div
+                    className={`h-full rounded-full transition-all ${getRiskBarColor(
+                      chaosResult.simulation_summary.risk_score
+                    )}`}
+                    style={{ width: `${chaosResult.simulation_summary.risk_score * 100}%` }}
+                  />
+                </div>
+              </div>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                {chaosResult.explanation}
+              </p>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/web/src/pages/Disclaimer.tsx
+++ b/web/src/pages/Disclaimer.tsx
@@ -1,0 +1,31 @@
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+
+export default function Disclaimer() {
+  const navigate = useNavigate();
+  return (
+    <div className="min-h-screen bg-background text-foreground px-6 py-8 flex flex-col">
+      <div className="max-w-2xl mx-auto text-left flex-1">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold tracking-tight text-foreground mb-4">
+            Disclaimer
+          </h1>
+          <div className="bg-card border border-border rounded-xl p-6">
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              This is an unofficial fan project created for educational and portfolio purposes. 
+              It is not affiliated with Formula 1, the FIA, any F1 team, driver, or data provider. 
+              All trademarks belong to their respective owners. Data is used under the terms of 
+              the respective source licenses and is intended for non-commercial personal use only.
+            </p>
+          </div>
+        </div>
+
+        <Button variant="outline" onClick={() => navigate("/")}>
+          <ArrowLeft size={16} className="mr-2" />
+          Back to Home
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/Methodology.tsx
+++ b/web/src/pages/Methodology.tsx
@@ -1,0 +1,64 @@
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+
+export default function Methodology() {
+  const navigate = useNavigate();
+  return (
+    <div className="min-h-screen bg-background text-foreground px-6 py-8 flex flex-col">
+      <div className="max-w-2xl mx-auto text-left flex-1">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold tracking-tight text-foreground mb-4">
+            Methodology
+          </h1>
+          <p className="text-muted-foreground text-base mb-6">
+            How Undercut works under the hood.
+          </p>
+        </div>
+
+        <div className="space-y-6 mb-8">
+          <section className="bg-card border border-border rounded-xl p-5">
+            <h2 className="text-lg font-semibold text-foreground mb-2">
+              Data Sources
+            </h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              We combine three primary data sources: <strong className="text-foreground">Jolpica</strong> for historical schedules, results, and standings; <strong className="text-foreground">OpenF1</strong> for modern session-level detail including stints, pit stops, weather, and race control events (2023+); and <strong className="text-foreground">FastF1</strong> for pre-2023 lap times and telemetry. When sources overlap, we apply a priority hierarchy: Jolpica for metadata, OpenF1 for modern detail, and FastF1 as the fallback for older seasons.
+            </p>
+          </section>
+
+          <section className="bg-card border border-border rounded-xl p-5">
+            <h2 className="text-lg font-semibold text-foreground mb-2">
+              Data Pipeline
+            </h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              Raw API payloads are stored immutably in <code className="text-xs bg-secondary px-1.5 py-0.5 rounded">data/raw/</code>. The normalize layer transforms these into a canonical DuckDB schema with dimension tables (seasons, circuits, drivers, compounds) and fact tables (laps, stints, pit stops, results, weather). From there we build race state tables that represent the field at any given lap, and a feature store that feeds the ML models and simulation engine.
+            </p>
+          </section>
+
+          <section className="bg-card border border-border rounded-xl p-5">
+            <h2 className="text-lg font-semibold text-foreground mb-2">
+              Machine Learning
+            </h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              Our v1 models are intentionally lightweight. We start with rule-based baselines, then layer on logistic regression, random forest, and XGBoost classifiers. We do not use deep learning or transformers — the goal is interpretability. Every pit-decision prediction is explained with SHAP values so you can see which signals (stint age, gap ahead, track temperature) drove the recommendation.
+            </p>
+          </section>
+
+          <section className="bg-card border border-border rounded-xl p-5">
+            <h2 className="text-lg font-semibold text-foreground mb-2">
+              Simulation Engine
+            </h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              The <strong className="text-foreground">UndercutEngine</strong> projects race outcomes using per-circuit constants (base lap time, pit loss, overtaking difficulty), a tire degradation model with cliff detection, and a pit-loss calculator that accounts for safety-car and VSC conditions. Your decision is scored against both the historical outcome and the simulation projection, producing a 0–100 score and a grade label.
+            </p>
+          </section>
+        </div>
+
+        <Button variant="outline" onClick={() => navigate("/")}>
+          <ArrowLeft size={16} className="mr-2" />
+          Back to Home
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/Methodology.tsx
+++ b/web/src/pages/Methodology.tsx
@@ -40,7 +40,7 @@ export default function Methodology() {
               Machine Learning
             </h2>
             <p className="text-sm text-muted-foreground leading-relaxed">
-              Our v1 models are intentionally lightweight. We start with rule-based baselines, then layer on logistic regression, random forest, and XGBoost classifiers. We do not use deep learning or transformers — the goal is interpretability. Every pit-decision prediction is explained with SHAP values so you can see which signals (stint age, gap ahead, track temperature) drove the recommendation.
+              Our v1 models use rule-based baseline models with 5 pit-decision rules and 3 finish-position rules. Confidence scores are derived from rule coverage. We do not use deep learning or transformers — the goal is interpretability. v2 may add gradient-boosted models (XGBoost) with SHAP explainability.
             </p>
           </section>
 

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Summary
- Add Chaos Engine UI to DecisionResult with 7 toggle modifiers
- Add Disclaimer and Methodology static pages
- Add Footer with navigation links
- Recreate rule-based ML baselines and ChaosEngine backend
- Add deployment configs (Railway Procfile, Vercel vercel.json)
- Rewrite README with architecture diagram and full setup instructions

## Test Plan
- [x] 85 backend tests pass
- [x] Frontend build succeeds
- [x] API imports correctly